### PR TITLE
docs(resend): standardize rahmanef sender policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@ HOSTINGER_API_TOKEN=your_hostinger_token_here
 # Get it: https://resend.com/api-keys   (verify a FROM domain first at https://resend.com/domains)
 # RESEND_API_KEY=
 # RESEND_FROM_DOMAIN=
+# Project-local first-party convention (do not store these globally when project names differ):
+# EMAIL_FROM_ADDRESS=official@rahmanef.com
+# EMAIL_PROJECT_NAME=<Project Name>
+# EMAIL_PROJECT_TAG=<project-slug>
+# EMAIL_REPLY_TO=
 
 # Supabase (future /sc-supabase — alt backend)
 # Get it: https://supabase.com/dashboard/account/tokens   (SUPABASE_ORG_ID = slug in /dashboard/org/<slug>)

--- a/skills/sc-onboarding/steps/resend.md
+++ b/skills/sc-onboarding/steps/resend.md
@@ -15,3 +15,21 @@ The verified sending domain (e.g. `mail.example.com`).
 **Get it:** https://resend.com/domains → **Add Domain** → add the shown DKIM/SPF records at your DNS provider → **Verify DNS Records**. `/sc-resend` will automate this via `/sc-cf` or `lib/hostinger.js`.
 
 **Validator**: contains a dot.
+
+
+## First-party `*.rahmanef.com` sender convention
+
+For Rahmanef-owned subdomain apps, do not create a per-subdomain From address.
+Use the verified shared identity `official@rahmanef.com`, with the application
+name as the display name and no reply-to by default. Examples:
+
+```text
+Play Together <official@rahmanef.com>
+Baton <official@rahmanef.com>
+```
+
+Project code should keep the address and project identity separate when
+possible (`EMAIL_FROM_ADDRESS`, `EMAIL_PROJECT_NAME`, `EMAIL_PROJECT_TAG`,
+optional `EMAIL_REPLY_TO`) and build the visible header at send time. A
+framework-specific combined variable such as Baton's `AUTH_EMAIL_FROM` may be
+used as an adapter, not as a second source of truth.

--- a/skills/sc-resend/SKILL.md
+++ b/skills/sc-resend/SKILL.md
@@ -14,6 +14,40 @@ description: "(STUB / NOT IMPLEMENTED YET) Transactional email via Resend — ve
 - **Audience** creation for broadcast lists (optional).
 - **Smoke send** to a verified recipient to confirm DNS propagation.
 
+
+## Rahmanef sender policy
+
+For first-party apps hosted on `*.rahmanef.com`, use one verified transactional
+identity and vary only the project display name:
+
+```text
+From: <Project Name> <official@rahmanef.com>
+Reply-To: (unset by default)
+```
+
+Do not derive the sender address from the app subdomain. For example,
+`baton.rahmanef.com` sends as `Baton <official@rahmanef.com>`, not
+`official@baton.rahmanef.com`. Preserve the existing verified Resend/DNS
+configuration for `rahmanef.com`; a transport or return-path hostname such as
+`send.rahmanef.com` is infrastructure, not the visible From identity.
+
+Recommended project-local env contract:
+
+```text
+EMAIL_FROM_ADDRESS=official@rahmanef.com
+EMAIL_PROJECT_NAME=<Project Name>
+EMAIL_PROJECT_TAG=<project-slug>
+EMAIL_REPLY_TO=
+```
+
+Framework adapters may map that SSOT into their native variable names. Example:
+Baton uses `AUTH_EMAIL_FROM="Baton <official@rahmanef.com>"`; Play Together
+builds the same header from `EMAIL_PROJECT_NAME` + `EMAIL_FROM_ADDRESS`. Keep
+reply-to absent unless the project has a distinct monitored mailbox. Future
+HTML templates should take the same project identity object for header, footer,
+subject prefix/tagging, and plaintext fallback rather than forking templates per
+application.
+
 ## Env vars
 
 | Var | Purpose |


### PR DESCRIPTION
## Summary
- standardize first-party `*.rahmanef.com` transactional sender as `<Project Name> <official@rahmanef.com>`
- keep reply-to unset by default
- document project-local identity envs for future dynamic header/footer templates
- clarify transport/return-path host is infrastructure, not the visible From address

## Verification
- `npm test` (198/198)
- `git diff --check`
