### PR TITLE
feat(flow): MVP sc flow runner with DAG parallel and MCP tools

### DIFF
--- a/bin/sc.js
+++ b/bin/sc.js
@@ -2345,6 +2345,79 @@ function cmdRecipe(sub, arg, args) {
   return die(`unknown: recipe ${sub}`);
 }
 
+
+function cmdFlow(sub, arg, args) {
+  const Flow = require('../lib/flow');
+  if (!sub || sub === 'list') {
+    const flows = Flow.listFlows({ root: process.cwd() });
+    const out = { flows };
+    return printJsonOr(out, args, row => {
+      if (!row.flows.length) return console.log('(no flows)');
+      for (const f of row.flows) {
+        const title = f.title ? `  ${f.title}` : '';
+        console.log(`${f.id}${title}  steps=${f.stepCount}`);
+      }
+    });
+  }
+  if (sub === 'show') {
+    if (!arg) die('usage: sc flow show <id|path>');
+    const doc = Flow.loadFlow(arg, { root: process.cwd() });
+    const { _source, ...rest } = doc;
+    const out = { ...rest, path: _source || null };
+    return printJsonOr(out, args, row => {
+      console.log(`${row.id}${row.title ? ` — ${row.title}` : ''}`);
+      if (row.description) console.log(row.description);
+      if (row.path) console.log(`path: ${row.path}`);
+      console.log('steps:');
+      for (const step of row.steps) {
+        const needs = step.needs?.length ? ` needs=[${step.needs.join(',')}]` : '';
+        console.log(`  - ${step.id} uses=${step.uses}${needs}`);
+      }
+    });
+  }
+  if (sub === 'validate') {
+    if (!arg) die('usage: sc flow validate <id|path>');
+    const doc = Flow.loadFlow(arg, { root: process.cwd() });
+    Flow.validateFlow(doc);
+    const out = { ok: true, id: doc.id, path: doc._source || null, stepCount: doc.steps.length };
+    return printJsonOr(out, args, row => console.log(`✅ flow ${row.id} valid (${row.stepCount} steps)`));
+  }
+  if (sub === 'run') {
+    if (!arg) die('usage: sc flow run <id|path> [--props JSON] [--props-file PATH] [--parallel N] [--dry-run] [--json]');
+    let props = {};
+    if (typeof args['props-file'] === 'string') {
+      const file = path.resolve(args['props-file']);
+      try { props = JSON.parse(fs.readFileSync(file, 'utf8')); }
+      catch (e) { die(`invalid --props-file: ${e.message}`); }
+    }
+    if (typeof args.props === 'string') {
+      try { props = { ...props, ...JSON.parse(args.props) }; }
+      catch (e) { die(`invalid --props JSON: ${e.message}`); }
+    }
+    if (!props || typeof props !== 'object' || Array.isArray(props)) die('--props must be a JSON object');
+    const parallel = args.parallel === undefined ? 4 : Number(args.parallel);
+    if (!Number.isFinite(parallel) || parallel < 1) die('--parallel must be a positive number');
+    const dryRun = Boolean(args['dry-run']);
+    return Flow.runFlow(Flow.loadFlow(arg, { root: process.cwd() }), {
+      props,
+      parallel,
+      dryRun,
+      root: path.resolve(__dirname, '..'),
+    }).then(out => {
+      printJsonOr(out, args, row => {
+        console.log(`${row.ok ? '✅' : '❌'} flow ${row.id}${row.dryRun ? ' (dry-run)' : ''}`);
+        for (const [id, step] of Object.entries(row.steps || {})) {
+          const mark = step.ok ? 'ok' : (step.continued ? 'continued' : 'fail');
+          console.log(`  ${id}: ${mark} ${step.ms}ms${step.error ? ` — ${step.error}` : ''}`);
+        }
+        if (!row.ok) process.exitCode = 1;
+      });
+      if (args.json && !out.ok) process.exitCode = 1;
+    });
+  }
+  return die(`unknown: flow ${sub}`);
+}
+
 function cmdSkillList(args) {
   const rows = listSkills({ includeInactive: Boolean(args.all) });
   if (args.json) {
@@ -2528,6 +2601,11 @@ sc — SI-Coder interactive console + secret control plane
   sc recipe verify <id> --yes          mark a repeated recipe verified
   sc recipe promote <id> --script scripts/name.js --yes
                                       bind a verified recipe to a deterministic executable script
+  sc flow [list]                       list packaged/project flow DAGs
+  sc flow show <id|path>               show one flow document
+  sc flow validate <id|path>           validate flow schema/DAG
+  sc flow run <id|path> [--props JSON] [--props-file PATH] [--parallel N] [--dry-run] [--json]
+                                      run a flow with custom props + parallel DAG execution
   sc skills [--all] [--json]            list canonical slash skills for compatible hosts
   sc skill list [--all] [--json]        alias for the machine-readable skill registry
   sc skill verify [--strict] [--json] validate skill metadata, trigger quality, references, tools, and secrets
@@ -2650,6 +2728,7 @@ async function main() {
     case 'task':      return cmdTask(sub, arg, args);
     case 'memory':    return cmdMemory(sub, arg, args);
     case 'recipe':    return cmdRecipe(sub, arg, args);
+    case 'flow':      return cmdFlow(sub, arg, args);
     case 'skills':    return cmdSkillList(args);
     case 'skill':     return cmdSkill(sub, args);
     case 'verify':    return cmdVerify(args);

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -265,6 +265,10 @@ sc.recipe.list
 sc.recipe.observe
 sc.recipe.verify
 sc.recipe.promote
+sc.flow.list
+sc.flow.show
+sc.flow.validate
+sc.flow.run
 sc.skill.verify
 sc.verify
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -308,6 +308,9 @@ sc recipe list
 sc recipe observe release-candidate-check --steps "syntax|tests|docs|catalog|skills|repository-secret-scan"
 sc recipe verify release-candidate-check --yes
 sc recipe promote release-candidate-check --script scripts/release-candidate-check.js --yes
+
+sc flow list
+sc flow run provider-health --dry-run --json
 ```
 
 Quality and verification:

--- a/docs/tool-calling.md
+++ b/docs/tool-calling.md
@@ -249,6 +249,10 @@ or:
 bash install.sh --agent openclaw --with-mcp
 ```
 
+## Flow runner (MVP)
+
+`sc flow` collapses multi-step provider/MCP work into one declarative DAG. Packaged flows live in `flows/*.json`; projects may overlay `.si-coder/flows/*.json`. Steps may use `sc.fn` (agent verbs via `scripts/sc-agent.js`), `sc.cli` (argv-only `bin/sc-entry.js`), `provider.mcp` (`doku` / `hostinger` mail with `confirm=true`), or recursive `flow` subflows (max depth 5). Templates support `{{props.*}}` and `{{steps.<id>.*}}`. Machine tools: `sc.flow.list`, `sc.flow.show`, `sc.flow.validate`, `sc.flow.run` (`timeoutMs` 120000 for run). Never put plaintext credentials in flow props.
+
 ## Safety contract
 
 - Machine schemas contain no plaintext-secret input field.

--- a/flows/README.md
+++ b/flows/README.md
@@ -5,7 +5,6 @@ Declarative DAGs that collapse multi-step `sc` / provider MCP work into one run.
 ## CLI
 
 ```bash
-export PATH="/home/rahman/.local/bin:$PATH"
 sc flow list
 sc flow show provider-health
 sc flow validate provider-health

--- a/flows/README.md
+++ b/flows/README.md
@@ -1,0 +1,38 @@
+# SI-Coder flows (MVP)
+
+Declarative DAGs that collapse multi-step `sc` / provider MCP work into one run.
+
+## CLI
+
+```bash
+export PATH="/home/rahman/.local/bin:$PATH"
+sc flow list
+sc flow show provider-health
+sc flow validate provider-health
+sc flow run provider-health --dry-run --json
+sc flow run provider-health --props '{"providers":["github"]}' --json
+```
+
+## Discovery
+
+1. Packaged `flows/*.json` in this repository
+2. Optional project overlay `.si-coder/flows/*.json`
+3. Absolute/relative path to a flow JSON file
+
+## Step kinds (`uses`)
+
+- `sc.fn` — `node scripts/sc-agent.js <name>` with JSON stdin (`with.name`, `with.input`)
+- `sc.cli` — `node bin/sc-entry.js` + argv array only (no shell)
+- `provider.mcp` — `doku` or `hostinger` mail helpers; requires `confirm=true`
+- `flow` — recursive subflow (`with.flow`, `with.props`); max depth 5
+
+## Templates
+
+- `{{props.path}}`
+- `{{steps.<id>.output.path}}` / `{{steps.<id>.ok}}`
+- Optional: `{{props.x?}}`
+- Whole-string tokens preserve non-string JSON values (arrays/objects)
+
+## Agents
+
+Machine tools: `sc.flow.list`, `sc.flow.show`, `sc.flow.validate`, `sc.flow.run`.

--- a/flows/provider-health.json
+++ b/flows/provider-health.json
@@ -1,0 +1,33 @@
+{
+  "id": "provider-health",
+  "title": "Provider health",
+  "description": "Run sc version and doctor in parallel for selected providers.",
+  "props": {
+    "type": "object",
+    "properties": {
+      "providers": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["github", "dokploy"]
+      }
+    },
+    "additionalProperties": false
+  },
+  "steps": [
+    {
+      "id": "version",
+      "uses": "sc.fn",
+      "with": { "name": "version" }
+    },
+    {
+      "id": "doctor",
+      "uses": "sc.fn",
+      "with": {
+        "name": "doctor",
+        "input": {
+          "providers": "{{props.providers}}"
+        }
+      }
+    }
+  ]
+}

--- a/lib/flow/index.js
+++ b/lib/flow/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { listFlows, loadFlow, validateFlow } = require('./load');
+const { runFlow } = require('./runner');
+
+module.exports = {
+  listFlows,
+  loadFlow,
+  validateFlow,
+  runFlow,
+};

--- a/lib/flow/load.js
+++ b/lib/flow/load.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { assertAllowedUses } = require('./security');
+
+const ROOT = path.resolve(__dirname, '../..');
+const PACKAGED_DIR = path.join(ROOT, 'flows');
+
+function isPlainObject(v) {
+  return Boolean(v) && typeof v === 'object' && !Array.isArray(v);
+}
+
+function validateFlow(doc) {
+  if (!isPlainObject(doc)) throw new Error('flow document must be a JSON object');
+  if (typeof doc.id !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,119}$/.test(doc.id)) {
+    throw new Error('flow.id is required and must be a safe identifier');
+  }
+  if (doc.title !== undefined && typeof doc.title !== 'string') throw new Error('flow.title must be a string');
+  if (doc.description !== undefined && typeof doc.description !== 'string') throw new Error('flow.description must be a string');
+  if (doc.props !== undefined) {
+    if (!isPlainObject(doc.props)) throw new Error('flow.props must be a JSON Schema object when present');
+    if (doc.props.type !== undefined && doc.props.type !== 'object') {
+      throw new Error('flow.props.type must be "object" when present');
+    }
+  }
+  if (!Array.isArray(doc.steps) || !doc.steps.length) throw new Error('flow.steps must be a non-empty array');
+
+  const ids = new Set();
+  for (const [index, step] of doc.steps.entries()) {
+    if (!isPlainObject(step)) throw new Error(`steps[${index}] must be an object`);
+    if (typeof step.id !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,119}$/.test(step.id)) {
+      throw new Error(`steps[${index}].id is required and must be a safe identifier`);
+    }
+    if (ids.has(step.id)) throw new Error(`duplicate step id: ${step.id}`);
+    ids.add(step.id);
+    assertAllowedUses(step.uses);
+    if (step.with !== undefined && !isPlainObject(step.with)) throw new Error(`steps[${index}].with must be an object`);
+    if (step.needs !== undefined) {
+      if (!Array.isArray(step.needs) || step.needs.some(x => typeof x !== 'string')) {
+        throw new Error(`steps[${index}].needs must be a string array`);
+      }
+    }
+    if (step.when !== undefined && typeof step.when !== 'string') {
+      throw new Error(`steps[${index}].when must be a string template when present`);
+    }
+    if (step.continueOnError !== undefined && typeof step.continueOnError !== 'boolean') {
+      throw new Error(`steps[${index}].continueOnError must be a boolean`);
+    }
+  }
+
+  for (const step of doc.steps) {
+    for (const need of step.needs || []) {
+      if (!ids.has(need)) throw new Error(`step ${step.id} needs unknown step "${need}"`);
+      if (need === step.id) throw new Error(`step ${step.id} cannot need itself`);
+    }
+  }
+
+  // Detect cycles via DFS
+  const byId = new Map(doc.steps.map(s => [s.id, s]));
+  const visiting = new Set();
+  const visited = new Set();
+  function visit(id) {
+    if (visited.has(id)) return;
+    if (visiting.has(id)) throw new Error(`flow has a cycle involving step "${id}"`);
+    visiting.add(id);
+    for (const need of byId.get(id).needs || []) visit(need);
+    visiting.delete(id);
+    visited.add(id);
+  }
+  for (const id of ids) visit(id);
+
+  return doc;
+}
+
+function readFlowFile(filePath) {
+  const abs = path.resolve(filePath);
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) throw new Error(`flow file not found: ${abs}`);
+  let doc;
+  try { doc = JSON.parse(fs.readFileSync(abs, 'utf8')); }
+  catch (e) { throw new Error(`invalid flow JSON ${abs}: ${e.message}`); }
+  validateFlow(doc);
+  return { ...doc, _source: abs };
+}
+
+function listFlowFiles(dir) {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
+  return fs.readdirSync(dir)
+    .filter(name => name.endsWith('.json'))
+    .map(name => path.join(dir, name))
+    .sort();
+}
+
+function discoverDirs(root = process.cwd()) {
+  const dirs = [PACKAGED_DIR];
+  const projectDir = path.join(path.resolve(root), '.si-coder', 'flows');
+  if (projectDir !== PACKAGED_DIR) dirs.push(projectDir);
+  return dirs;
+}
+
+function listFlows({ root = process.cwd() } = {}) {
+  const seen = new Map();
+  for (const dir of discoverDirs(root)) {
+    for (const file of listFlowFiles(dir)) {
+      try {
+        const doc = readFlowFile(file);
+        // Project flows override packaged flows with the same id.
+        seen.set(doc.id, {
+          id: doc.id,
+          title: doc.title || null,
+          description: doc.description || null,
+          path: doc._source,
+          stepCount: doc.steps.length,
+        });
+      } catch {
+        // Skip invalid discovery candidates; load/validate surfaces errors explicitly.
+      }
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function loadFlow(idOrPath, { root = process.cwd() } = {}) {
+  if (typeof idOrPath !== 'string' || !idOrPath.trim()) throw new Error('flow id or path is required');
+  const raw = idOrPath.trim();
+
+  if (raw.endsWith('.json') || raw.includes('/') || raw.includes(path.sep) || raw.startsWith('.')) {
+    return readFlowFile(path.isAbsolute(raw) ? raw : path.resolve(root, raw));
+  }
+
+  // Prefer project overlay, then packaged.
+  const candidates = [];
+  for (const dir of discoverDirs(root).reverse()) {
+    candidates.push(path.join(dir, `${raw}.json`));
+  }
+  // Also allow matching by id inside listed files (filename may differ).
+  for (const dir of discoverDirs(root).reverse()) {
+    for (const file of listFlowFiles(dir)) {
+      try {
+        const doc = readFlowFile(file);
+        if (doc.id === raw) return doc;
+      } catch { /* ignore */ }
+    }
+  }
+  for (const file of candidates) {
+    if (fs.existsSync(file)) return readFlowFile(file);
+  }
+  throw new Error(`flow not found: ${raw}`);
+}
+
+module.exports = {
+  ROOT,
+  PACKAGED_DIR,
+  validateFlow,
+  listFlows,
+  loadFlow,
+};

--- a/lib/flow/runner.js
+++ b/lib/flow/runner.js
@@ -1,0 +1,356 @@
+'use strict';
+
+const path = require('path');
+const { spawn } = require('child_process');
+const { interpolate } = require('./template');
+const { assertAllowedUses, assertFlowSecrets } = require('./security');
+const { loadFlow, ROOT } = require('./load');
+
+function nowIso() { return new Date().toISOString(); }
+
+function spawnCapture(file, argv, { cwd, input, env, timeoutMs = 120000 } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(file, argv, {
+      cwd,
+      env: env || process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill('SIGKILL');
+      resolve({ code: 124, stdout, stderr: stderr + `\ntimeout after ${timeoutMs}ms` });
+    }, timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', c => { stdout += c; if (stdout.length > 2 * 1024 * 1024) stdout = stdout.slice(0, 2 * 1024 * 1024); });
+    child.stderr.on('data', c => { stderr += c; if (stderr.length > 512 * 1024) stderr = stderr.slice(0, 512 * 1024); });
+    child.on('error', err => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code: 1, stdout, stderr: String(err.message || err) });
+    });
+    child.on('close', code => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code: code === null ? 1 : code, stdout, stderr });
+    });
+    if (input !== undefined && input !== null) {
+      child.stdin.end(typeof input === 'string' ? input : JSON.stringify(input));
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function tryParseJson(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+function parseStdoutJson(stdout) {
+  const parsed = tryParseJson(stdout);
+  if (parsed !== null) return parsed;
+  // Prefer the last JSON object in mixed stdout.
+  const match = String(stdout || '').match(/\{[\s\S]*\}\s*$/);
+  if (match) {
+    const again = tryParseJson(match[0]);
+    if (again !== null) return again;
+  }
+  return { stdout: String(stdout || '') };
+}
+
+async function handleScFn(stepWith, { root, dryRun }) {
+  const name = stepWith.name;
+  if (typeof name !== 'string' || !name.trim()) throw new Error('sc.fn requires with.name');
+  const input = stepWith.input === undefined ? {} : stepWith.input;
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('sc.fn with.input must be an object when present');
+  }
+  assertFlowSecrets(input, `sc.fn:${name}:input`);
+  const agent = path.join(root, 'scripts/sc-agent.js');
+  if (dryRun) {
+    return { dryRun: true, uses: 'sc.fn', name, input };
+  }
+  const result = await spawnCapture(process.execPath, [agent, name], {
+    cwd: root,
+    input,
+  });
+  const output = parseStdoutJson(result.stdout);
+  if (result.code !== 0) {
+    const err = result.stderr.trim() || (output && output.error) || `sc.fn ${name} exited ${result.code}`;
+    const error = new Error(typeof err === 'string' ? err : JSON.stringify(err));
+    error.output = output;
+    error.code = result.code;
+    throw error;
+  }
+  return output;
+}
+
+async function handleScCli(stepWith, { root, dryRun }) {
+  let argv = stepWith.argv;
+  if (!Array.isArray(argv) || !argv.length) throw new Error('sc.cli requires with.argv string array');
+  argv = argv.map(x => {
+    if (typeof x !== 'string') throw new Error('sc.cli argv entries must be strings');
+    if (/[\s;$`|&<>]/.test(x)) throw new Error(`sc.cli rejects shell-metacharacter argv entry: ${JSON.stringify(x)}`);
+    return x;
+  });
+  const entry = path.join(root, 'bin/sc-entry.js');
+  if (dryRun) {
+    return { dryRun: true, uses: 'sc.cli', argv };
+  }
+  const result = await spawnCapture(process.execPath, [entry, ...argv], { cwd: root });
+  const output = parseStdoutJson(result.stdout);
+  if (result.code !== 0) {
+    const err = result.stderr.trim() || `sc.cli exited ${result.code}`;
+    const error = new Error(err);
+    error.output = output;
+    error.code = result.code;
+    throw error;
+  }
+  return output;
+}
+
+async function handleProviderMcp(stepWith, { dryRun }) {
+  const provider = stepWith.provider;
+  const user = stepWith.user;
+  const connection = stepWith.connection;
+  const tool = stepWith.tool;
+  const toolArgs = stepWith.arguments === undefined ? {} : stepWith.arguments;
+  const confirm = stepWith.confirm;
+
+  if (typeof provider !== 'string' || !provider.trim()) throw new Error('provider.mcp requires with.provider');
+  if (typeof user !== 'string' || !user.trim()) throw new Error('provider.mcp requires with.user');
+  if (typeof connection !== 'string' || !connection.trim()) throw new Error('provider.mcp requires with.connection');
+  if (typeof tool !== 'string' || !tool.trim()) throw new Error('provider.mcp requires with.tool');
+  if (!toolArgs || typeof toolArgs !== 'object' || Array.isArray(toolArgs)) {
+    throw new Error('provider.mcp with.arguments must be an object');
+  }
+  if (confirm !== true) throw new Error('provider.mcp requires with.confirm=true');
+  assertFlowSecrets({ user, connection, tool, arguments: toolArgs }, 'provider.mcp');
+
+  if (dryRun) {
+    return { dryRun: true, uses: 'provider.mcp', provider, user, connection, tool, arguments: toolArgs, confirm: true };
+  }
+
+  if (provider === 'doku') {
+    const C = require('../connections');
+    const D = require('../doku-mcp');
+    const conn = C.get(user, 'doku', connection);
+    if (conn.source !== 'sc' || conn.authMethod !== 'mcp-api-key') {
+      throw new Error('DOKU MCP requires source=sc auth method mcp-api-key');
+    }
+    const values = C.readValues(user, 'doku', conn.id);
+    const response = await D.call(values, tool, toolArgs);
+    return { provider, user, connection: conn.id, tool, environment: response.environment, result: response.result };
+  }
+
+  if (provider === 'hostinger') {
+    const H = require('../hostinger-mail');
+    if (tool === 'orders') return { provider, user, connection, tool, result: await H.orders(user, connection) };
+    if (tool === 'list') {
+      return {
+        provider, user, connection, tool,
+        result: await H.list(user, connection, toolArgs.resource, toolArgs.orderId, toolArgs.page),
+      };
+    }
+    if (tool === 'logs') {
+      return {
+        provider, user, connection, tool,
+        result: await H.logs(user, connection, toolArgs.kind, toolArgs.orderId, toolArgs.page),
+      };
+    }
+    if (tool === 'mutate') {
+      return {
+        provider, user, connection, tool,
+        result: await H.mutate(user, connection, toolArgs.operation, toolArgs.arguments || toolArgs),
+      };
+    }
+    throw new Error(`unsupported hostinger mail tool "${tool}" (orders|list|logs|mutate)`);
+  }
+
+  throw new Error(`unsupported provider.mcp provider "${provider}" (supported: doku, hostinger)`);
+}
+
+async function handleFlow(stepWith, opts) {
+  const flowId = stepWith.flow;
+  if (typeof flowId !== 'string' || !flowId.trim()) throw new Error('flow step requires with.flow');
+  const props = stepWith.props === undefined ? {} : stepWith.props;
+  if (!props || typeof props !== 'object' || Array.isArray(props)) throw new Error('flow with.props must be an object');
+  if (opts.dryRun) {
+    return { dryRun: true, uses: 'flow', flow: flowId, props, depth: opts.depth + 1 };
+  }
+  const childDoc = loadFlow(flowId, { root: opts.root });
+  const result = await runFlow(childDoc, {
+    props,
+    parallel: opts.parallel,
+    dryRun: opts.dryRun,
+    root: opts.root,
+    depth: opts.depth + 1,
+    maxDepth: opts.maxDepth,
+  });
+  if (!result.ok) {
+    const error = new Error(result.error || result.steps && Object.values(result.steps).find(s => s && s.error)?.error || `subflow ${flowId} failed`);
+    error.output = result;
+    throw error;
+  }
+  return result;
+}
+
+async function runStep(step, ctx, opts) {
+  assertAllowedUses(step.uses);
+  const interpolated = interpolate(step.with || {}, ctx);
+  assertFlowSecrets(interpolated, `step:${step.id}:with`);
+
+  if (opts.dryRun && step.uses !== 'flow') {
+    // Still dispatch so handlers return dry-run payloads consistently.
+  }
+
+  switch (step.uses) {
+    case 'sc.fn': return handleScFn(interpolated, opts);
+    case 'sc.cli': return handleScCli(interpolated, opts);
+    case 'provider.mcp': return handleProviderMcp(interpolated, opts);
+    case 'flow': return handleFlow(interpolated, opts);
+    default: throw new Error(`unsupported uses: ${step.uses}`);
+  }
+}
+
+function truthyWhen(when, ctx) {
+  if (when === undefined || when === null || when === '') return true;
+  // MVP stub: interpolate and treat non-empty / non-falsey strings as true.
+  const value = interpolate(when, ctx);
+  if (value === false || value === 0 || value === 'false' || value === '0' || value === '' || value == null) return false;
+  return true;
+}
+
+async function runFlow(doc, {
+  props = {},
+  parallel = 4,
+  dryRun = false,
+  root = ROOT,
+  depth = 0,
+  maxDepth = 5,
+} = {}) {
+  if (depth > maxDepth) {
+    throw new Error(`flow recursion exceeded maxDepth=${maxDepth}`);
+  }
+  if (!props || typeof props !== 'object' || Array.isArray(props)) {
+    throw new Error('props must be an object');
+  }
+  assertFlowSecrets(props, 'flow.props');
+
+  // Apply simple defaults from JSON Schema props.properties.*.default
+  const mergedProps = { ...props };
+  const schemaProps = doc.props && doc.props.properties && typeof doc.props.properties === 'object'
+    ? doc.props.properties
+    : {};
+  for (const [key, schema] of Object.entries(schemaProps)) {
+    if (mergedProps[key] === undefined && schema && Object.prototype.hasOwnProperty.call(schema, 'default')) {
+      mergedProps[key] = schema.default;
+    }
+  }
+
+  const startedAt = nowIso();
+  const steps = {};
+  const pending = new Map(doc.steps.map(s => [s.id, s]));
+  const running = new Map();
+  const limit = Math.max(1, Math.min(32, Number(parallel) || 4));
+  let failed = false;
+  let fatalError = null;
+
+  const ctx = () => ({ props: mergedProps, steps });
+
+  function readyIds() {
+    const out = [];
+    for (const [id, step] of pending) {
+      const needs = step.needs || [];
+      const ready = needs.every(n => steps[n] && (steps[n].ok || steps[n].continued));
+      if (ready) out.push(id);
+    }
+    return out;
+  }
+
+  async function launch(id) {
+    const step = pending.get(id);
+    pending.delete(id);
+    const t0 = Date.now();
+    const promise = (async () => {
+      try {
+        if (!truthyWhen(step.when, ctx())) {
+          steps[id] = { ok: true, skipped: true, ms: Date.now() - t0, output: { skipped: true } };
+          return;
+        }
+        const output = await runStep(step, ctx(), { props: mergedProps, parallel: limit, dryRun, root, depth, maxDepth });
+        steps[id] = { ok: true, ms: Date.now() - t0, output };
+      } catch (e) {
+        const entry = {
+          ok: false,
+          ms: Date.now() - t0,
+          output: e.output || null,
+          error: String(e.message || e),
+        };
+        if (step.continueOnError === true) {
+          entry.continued = true;
+          steps[id] = entry;
+        } else {
+          steps[id] = entry;
+          failed = true;
+          fatalError = e;
+          // Cancel launching more; in-flight continue but new ready steps stop.
+        }
+      }
+    })();
+    running.set(id, promise);
+    try { await promise; }
+    finally { running.delete(id); }
+  }
+
+  while (pending.size || running.size) {
+    if (failed) {
+      // Wait for in-flight only; do not start new work.
+      if (!running.size) break;
+      await Promise.race([...running.values()]);
+      continue;
+    }
+    const ready = readyIds().filter(id => !running.has(id));
+    while (running.size < limit && ready.length) {
+      const id = ready.shift();
+      // fire and track without awaiting individually here
+      launch(id);
+    }
+    if (!running.size && pending.size) {
+      // Deadlock: remaining steps depend on failed/missing parents.
+      failed = true;
+      fatalError = fatalError || new Error('flow stalled: remaining steps cannot become ready');
+      for (const [id] of pending) {
+        steps[id] = { ok: false, ms: 0, output: null, error: 'not started (dependency failure or stall)' };
+      }
+      pending.clear();
+      break;
+    }
+    if (running.size) await Promise.race([...running.values()]);
+  }
+
+  const finishedAt = nowIso();
+  const ok = !failed && Object.values(steps).every(s => s.ok || s.continued);
+  const result = {
+    id: doc.id,
+    ok,
+    dryRun: Boolean(dryRun),
+    props: mergedProps,
+    steps,
+    startedAt,
+    finishedAt,
+  };
+  if (!ok && fatalError) result.error = String(fatalError.message || fatalError);
+  return result;
+}
+
+module.exports = { runFlow };

--- a/lib/flow/security.js
+++ b/lib/flow/security.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { assertNoSecrets } = require('../agent/security');
+
+const ALLOWED_USES = Object.freeze(new Set(['sc.fn', 'sc.cli', 'provider.mcp', 'flow']));
+
+function assertAllowedUses(uses) {
+  if (typeof uses !== 'string' || !uses.trim()) throw new Error('step.uses is required');
+  if (!ALLOWED_USES.has(uses)) {
+    throw new Error(`step.uses "${uses}" is not allowlisted (allowed: ${[...ALLOWED_USES].join(', ')})`);
+  }
+  return uses;
+}
+
+function assertFlowSecrets(value, label) {
+  assertNoSecrets(value, label);
+}
+
+module.exports = {
+  ALLOWED_USES,
+  assertAllowedUses,
+  assertFlowSecrets,
+  assertNoSecrets,
+};

--- a/lib/flow/template.js
+++ b/lib/flow/template.js
@@ -1,0 +1,67 @@
+'use strict';
+
+function getByPath(obj, path) {
+  if (path === '' || path == null) return obj;
+  const parts = String(path).split('.').filter(Boolean);
+  let cur = obj;
+  for (const part of parts) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof cur !== 'object') return undefined;
+    if (!(part in cur)) return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+function resolveToken(expr, ctx) {
+  const raw = String(expr || '').trim();
+  if (!raw) throw new Error('empty template token');
+  const optional = raw.endsWith('?');
+  const path = optional ? raw.slice(0, -1) : raw;
+
+  let value;
+  if (path.startsWith('props.')) value = getByPath(ctx.props, path.slice(6));
+  else if (path === 'props') value = ctx.props;
+  else if (path.startsWith('steps.')) value = getByPath(ctx.steps, path.slice(6));
+  else if (path === 'steps') value = ctx.steps;
+  else throw new Error(`unsupported template root in "${raw}" (use props.* or steps.*)`);
+
+  if (value === undefined) {
+    if (optional) return undefined;
+    throw new Error(`template path not found: ${path}`);
+  }
+  return value;
+}
+
+/**
+ * Interpolate {{props...}} / {{steps...}} tokens.
+ * If the entire string is a single token and the resolved value is non-string,
+ * return the raw value so arrays/objects can pass through.
+ */
+function interpolate(value, ctx) {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (Array.isArray(value)) return value.map(v => interpolate(v, ctx));
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) out[k] = interpolate(v, ctx);
+    return out;
+  }
+  if (typeof value !== 'string') return value;
+
+  const whole = value.match(/^\{\{\s*([^}]+?)\s*\}\}$/);
+  if (whole) {
+    const resolved = resolveToken(whole[1], ctx);
+    return resolved === undefined ? undefined : resolved;
+  }
+
+  return value.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (match, expr) => {
+    const resolved = resolveToken(expr, ctx);
+    if (resolved === undefined) return '';
+    if (resolved === null) return 'null';
+    if (typeof resolved === 'object') return JSON.stringify(resolved);
+    return String(resolved);
+  });
+}
+
+module.exports = { getByPath, resolveToken, interpolate };

--- a/machine/functions.json
+++ b/machine/functions.json
@@ -1972,6 +1972,105 @@
         "additionalProperties": false
       },
       "timeoutMs": 30000
+    },
+    {
+      "name": "sc.flow.list",
+      "description": "List packaged and project-local SI-Coder flow DAGs without executing them.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "command": [
+        "node",
+        "scripts/sc-agent.js",
+        "flow.list"
+      ],
+      "timeoutMs": 10000
+    },
+    {
+      "name": "sc.flow.show",
+      "description": "Show one SI-Coder flow document by id or path.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      },
+      "command": [
+        "node",
+        "scripts/sc-agent.js",
+        "flow.show"
+      ],
+      "timeoutMs": 10000
+    },
+    {
+      "name": "sc.flow.validate",
+      "description": "Validate one SI-Coder flow schema and DAG by id or path.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      },
+      "command": [
+        "node",
+        "scripts/sc-agent.js",
+        "flow.validate"
+      ],
+      "timeoutMs": 10000
+    },
+    {
+      "name": "sc.flow.run",
+      "description": "Run one SI-Coder flow DAG with custom props, optional parallelism, and optional dry-run. Recursive subflows are depth-limited. Never accepts plaintext secrets.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "props": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "parallel": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 32
+          },
+          "dryRun": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      },
+      "command": [
+        "node",
+        "scripts/sc-agent.js",
+        "flow.run"
+      ],
+      "timeoutMs": 120000
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "references/",
     ".mcp.json",
     "machine/",
+    "flows/",
     ".claude-plugin/",
     "lib/",
     "scripts/",

--- a/scripts/sc-agent.js
+++ b/scripts/sc-agent.js
@@ -172,6 +172,45 @@ async function main() {
       process.stdout.write(`${JSON.stringify(AgentActions.recipePromoteAction(input), null, 2)}\n`);
       return;
     }
+    case 'flow.list': {
+      const Flow = require('../lib/flow');
+      process.stdout.write(`${JSON.stringify({ flows: Flow.listFlows({ root: process.cwd() }) }, null, 2)}\n`);
+      return;
+    }
+    case 'flow.show': {
+      const Flow = require('../lib/flow');
+      const id = assertString(input.id || input.path, 'id');
+      const doc = Flow.loadFlow(id, { root: process.cwd() });
+      const { _source, ...rest } = doc;
+      process.stdout.write(`${JSON.stringify({ ...rest, path: _source || null }, null, 2)}\n`);
+      return;
+    }
+    case 'flow.validate': {
+      const Flow = require('../lib/flow');
+      const id = assertString(input.id || input.path, 'id');
+      const doc = Flow.loadFlow(id, { root: process.cwd() });
+      Flow.validateFlow(doc);
+      process.stdout.write(`${JSON.stringify({ ok: true, id: doc.id, path: doc._source || null, stepCount: doc.steps.length }, null, 2)}\n`);
+      return;
+    }
+    case 'flow.run': {
+      const Flow = require('../lib/flow');
+      const id = assertString(input.id || input.path, 'id');
+      const props = input.props === undefined ? {} : input.props;
+      if (!props || typeof props !== 'object' || Array.isArray(props)) throw new Error('props must be an object');
+      const parallel = input.parallel === undefined ? 4 : Number(input.parallel);
+      if (!Number.isFinite(parallel) || parallel < 1) throw new Error('parallel must be a positive number');
+      const dryRun = input.dryRun === true;
+      const out = await Flow.runFlow(Flow.loadFlow(id, { root: process.cwd() }), {
+        props,
+        parallel,
+        dryRun,
+        root: path.resolve(__dirname, '..'),
+      });
+      process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+      process.exitCode = out.ok ? 0 : 1;
+      return;
+    }
     case 'verify': {
       const out = AgentActions.repositoryVerifyAction(input);
       process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);

--- a/test/flow.test.js
+++ b/test/flow.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const Flow = require('../lib/flow');
+const { interpolate } = require('../lib/flow/template');
+const { validateFlow, loadFlow, listFlows } = require('../lib/flow/load');
+const { runFlow } = require('../lib/flow/runner');
+
+test('flow validate accepts provider-health and rejects bad docs', () => {
+  const good = loadFlow('provider-health', { root: ROOT });
+  assert.equal(good.id, 'provider-health');
+  assert.equal(good.steps.length, 2);
+  validateFlow(good);
+
+  assert.throws(() => validateFlow({ id: 'x', steps: [] }), /non-empty/);
+  assert.throws(() => validateFlow({
+    id: 'bad-uses',
+    steps: [{ id: 'a', uses: 'shell' }],
+  }), /allowlisted/);
+  assert.throws(() => validateFlow({
+    id: 'dup',
+    steps: [
+      { id: 'a', uses: 'sc.fn', with: { name: 'version' } },
+      { id: 'a', uses: 'sc.fn', with: { name: 'version' } },
+    ],
+  }), /duplicate/);
+  assert.throws(() => validateFlow({
+    id: 'cycle',
+    steps: [
+      { id: 'a', uses: 'sc.fn', needs: ['b'], with: { name: 'version' } },
+      { id: 'b', uses: 'sc.fn', needs: ['a'], with: { name: 'version' } },
+    ],
+  }), /cycle/);
+});
+
+test('template interpolates dotted paths and preserves object/array whole-string values', () => {
+  const ctx = {
+    props: { providers: ['github', 'dokploy'], name: 'rahman' },
+    steps: {
+      version: { ok: true, output: { version: '0.9.0', nested: { x: 1 } } },
+    },
+  };
+  assert.equal(interpolate('hi {{props.name}}', ctx), 'hi rahman');
+  assert.deepEqual(interpolate('{{props.providers}}', ctx), ['github', 'dokploy']);
+  assert.equal(interpolate('{{steps.version.ok}}', ctx), true);
+  assert.deepEqual(interpolate({ providers: '{{props.providers}}' }, ctx), { providers: ['github', 'dokploy'] });
+  assert.equal(interpolate('{{props.missing?}}', ctx), undefined);
+  assert.throws(() => interpolate('{{props.missing}}', ctx), /not found/);
+  assert.equal(interpolate('{{steps.version.output.nested.x}}', ctx), 1);
+});
+
+test('listFlows discovers packaged provider-health', () => {
+  const rows = listFlows({ root: ROOT });
+  assert.ok(rows.some(r => r.id === 'provider-health'));
+});
+
+test('dry-run provider-health returns structured parallel step results', async () => {
+  const doc = loadFlow('provider-health', { root: ROOT });
+  const out = await runFlow(doc, {
+    props: {},
+    dryRun: true,
+    parallel: 4,
+    root: ROOT,
+  });
+  assert.equal(out.id, 'provider-health');
+  assert.equal(out.ok, true);
+  assert.equal(out.dryRun, true);
+  assert.deepEqual(out.props.providers, ['github', 'dokploy']);
+  assert.equal(out.steps.version.ok, true);
+  assert.equal(out.steps.doctor.ok, true);
+  assert.equal(out.steps.version.output.uses, 'sc.fn');
+  assert.equal(out.steps.doctor.output.name, 'doctor');
+  assert.deepEqual(out.steps.doctor.output.input.providers, ['github', 'dokploy']);
+});
+
+test('DAG independent steps both complete under parallel dry-run', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-flow-'));
+  const file = path.join(dir, 'parallel.json');
+  fs.writeFileSync(file, JSON.stringify({
+    id: 'parallel-demo',
+    steps: [
+      { id: 'a', uses: 'sc.fn', with: { name: 'version' } },
+      { id: 'b', uses: 'sc.fn', with: { name: 'version' } },
+    ],
+  }));
+  const doc = loadFlow(file, { root: ROOT });
+  const out = await runFlow(doc, { dryRun: true, parallel: 2, root: ROOT });
+  assert.equal(out.ok, true);
+  assert.ok(out.steps.a.ok && out.steps.b.ok);
+});
+
+test('recursive maxDepth refuses deeper nesting', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-flow-nest-'));
+  const file = path.join(dir, 'nest.json');
+  fs.writeFileSync(file, JSON.stringify({
+    id: 'nest',
+    steps: [
+      {
+        id: 'child',
+        uses: 'flow',
+        with: { flow: file, props: {} },
+      },
+    ],
+  }));
+  const doc = loadFlow(file, { root: ROOT });
+  const nested = await runFlow(doc, { dryRun: false, root: ROOT, maxDepth: 2, depth: 0 });
+  assert.equal(nested.ok, false);
+  assert.match(String(nested.steps.child?.error || nested.error || ''), /maxDepth/);
+  await assert.rejects(
+    () => runFlow(doc, { dryRun: true, root: ROOT, maxDepth: 1, depth: 2 }),
+    /maxDepth/,
+  );
+});
+
+test('Flow index re-exports', () => {
+  assert.equal(typeof Flow.listFlows, 'function');
+  assert.equal(typeof Flow.loadFlow, 'function');
+  assert.equal(typeof Flow.validateFlow, 'function');
+  assert.equal(typeof Flow.runFlow, 'function');
+});

--- a/test/flow.test.js
+++ b/test/flow.test.js
@@ -58,6 +58,8 @@ test('template interpolates dotted paths and preserves object/array whole-string
 test('listFlows discovers packaged provider-health', () => {
   const rows = listFlows({ root: ROOT });
   assert.ok(rows.some(r => r.id === 'provider-health'));
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  assert.ok(pkg.files.includes('flows/'), 'packaged flow DAGs must ship in the npm package');
 });
 
 test('dry-run provider-health returns structured parallel step results', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Collapse multi-tool provider/MCP processes into one `sc flow run` / `sc.flow.run` so agents can execute a named DAG with custom props, parallel independent steps, and recursive subflows.

## Why

Agents currently chain many `sc` / provider MCP calls for the same health or provider process. A flow document turns that into one run: custom props, DAG-parallel steps (`needs`), and depth-limited recursive subflows. Secrets stay on named connections; props go through `assertNoSecrets`; step `uses` is allowlisted (`sc.fn`, `sc.cli`, `provider.mcp`, `flow`).

## What shipped

- CLI: `sc flow list|show|validate|run` (`--props`, `--props-file`, `--parallel`, `--dry-run`, `--json`)
- MCP / machine tools: `sc.flow.list`, `sc.flow.show`, `sc.flow.validate`, `sc.flow.run`
- Example DAG: `flows/provider-health.json` (parallel `version` + `doctor`)
- Runner: `lib/flow/*` (schema/DAG validation, templates, parallel scheduler, maxDepth 5)
- Tests: `test/flow.test.js`
- Docs: `flows/README.md`, `docs/cli.md`, `docs/tool-calling.md`, `docs/agent-workflow.md`

Packaged `flows/` is included in the npm `files` list so `provider-health` ships with the install.

## How to try

```bash
node --test test/flow.test.js
node bin/sc-entry.js flow list
node bin/sc-entry.js flow run provider-health --dry-run --json
```

Human-readable equivalents: `sc flow list`, `sc flow show provider-health`, `sc flow validate provider-health`, `sc flow run provider-health --props '{"providers":["github"]}' --json`.

## Security

- Provider credentials stay on named connections (`provider.mcp` requires `user`, `connection`, and `confirm=true`)
- Flow props and interpolated `with` pass through `assertNoSecrets` (same secret-shaped field/value scanner as the agent surface)
- `step.uses` is allowlisted; `sc.cli` is argv-only (no shell)
- Recursive subflows are capped (`maxDepth` default 5)
- Machine schemas have no plaintext-secret input fields

## Review notes

Review-only polish on this branch (no runner rewrite):

- Add `flows/` to `package.json` `files` so packaged DAGs survive `npm pack`
- List `sc.flow.*` on the agent-workflow machine surface
- Drop an owner-specific `PATH` from `flows/README.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11a924a5-f17a-536a-9a1f-00bb88673ebd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11a924a5-f17a-536a-9a1f-00bb88673ebd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

